### PR TITLE
Remove obsolete z-index variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,6 @@
 
 ### Removed
 
-- `Z-index`: removed the the obsolete `z-index variables`. ([@driesd](https://github.com/driesd) in [#4](https://github.com/teamleadercrm/ui-utilities/pull/4))
+- [BREAKING] `Z-index`: removed the the obsolete `z-index variables`. ([@driesd](https://github.com/driesd) in [#4](https://github.com/teamleadercrm/ui-utilities/pull/4))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ### Added
 
 - initial changelog
+- initial readme
 
 ### Changed
 
 ### Deprecated
 
 ### Removed
+
+- `Z-index`: removed the the obsolete `z-index variables`. ([@driesd](https://github.com/driesd) in [#4](https://github.com/teamleadercrm/ui-utilities/pull/4))
 
 ### Fixed

--- a/index.css
+++ b/index.css
@@ -11,12 +11,6 @@
   --spacer-bigger: calc(16 * var(--spacer-unit));
   --spacer-biggest: calc(24 * var(--spacer-unit));
 
-  --z-index-higher: 200;
-  --z-index-high: 100;
-  --z-index-normal: 1;
-  --z-index-low: -100;
-  --z-index-lower: -200;
-
   --box-shadow-100: 0 1px 1px 0 color(var(--color-teal-darkest) a(12%));
   --box-shadow-200: 0 4px 6px 0 color(var(--color-teal-darkest) a(32%));
   --box-shadow-300: 0 8px 10px 0 color(var(--color-teal-darkest) a(32%));


### PR DESCRIPTION
### Description

This PR removes the obsolete `z-index variables`, since they were not making very much sense anymore.

### Breaking changes

The following css variables have been removed:

* --z-index-higher
* --z-index-high
* --z-index-normal
* --z-index-low
* --z-index-lower