### PR TITLE
Add border-radius variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `Border radius`: added `border-radius` variables ([@driesd](https://github.com/driesd) in [#6](https://github.com/teamleadercrm/ui-utilities/pull/6))
 - initial changelog
 
 ### Changed

--- a/index.css
+++ b/index.css
@@ -17,6 +17,11 @@
   --z-index-low: -100;
   --z-index-lower: -200;
 
+  --border-radius-small: 2px;
+  --border-radius-medium: 4px;
+  --border-radius-large: 8px;
+  --border-radius-round: 50%;
+
   --box-shadow-100: 0 1px 1px 0 color(var(--color-teal-darkest) a(12%));
   --box-shadow-200: 0 4px 6px 0 color(var(--color-teal-darkest) a(32%));
   --box-shadow-300: 0 8px 10px 0 color(var(--color-teal-darkest) a(32%));


### PR DESCRIPTION
### Description

This PR adds the following reusable `border-radius` variables:

* --border-radius-small: 2px;
* --border-radius-medium: 4px;
* --border-radius-large: 8px;
* --border-radius-round: 50%;

### Breaking changes

None.