### PR TITLE
Disable user select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Disable user select`: added a `.disable-user-select` class to prevent the user from selecting text. ([@driesd](https://github.com/driesd) in [#10](https://github.com/teamleadercrm/ui-utilities/pull/10))
+
 ### Changed
 
 ### Deprecated

--- a/index.css
+++ b/index.css
@@ -87,6 +87,13 @@
   z-index: -1;
 }
 
+.disable-user-select {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 /* Orientation */
 @custom-media --portrait (orientation: portrait);
 @custom-media --landscape (orientation: landscape);


### PR DESCRIPTION
This PR adds a `disable-user-select` class to prevent the user from selecting text.