### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixed
 
+## [0.2.0] - 2019-11-19
+
+### Changed
+
+- `Clearfix`: renamed `clearfix` selector from `.cf` to `.clearfix` ([@driesd](https://github.com/driesd) in [#11](https://github.com/teamleadercrm/ui-utilities/pull/11))
+
 ## [0.1.2] - 2019-11-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-utilities",
   "private": false,
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Teamleader UI utilities",
   "main": "index.css",
   "repository": {


### PR DESCRIPTION
### Changed

- `Clearfix`: renamed `clearfix` selector from `.cf` to `.clearfix` ([@driesd](https://github.com/driesd) in [#11](https://github.com/teamleadercrm/ui-utilities/pull/11))