### PR TITLE
Stop using @composes to avoid error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- '@composes': remove all usages of `@composes` to avoid errors. ([@driesd](https://github.com/driesd) in [#15](https://github.com/teamleadercrm/ui-utilities/pull/15))
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@
 
 ### Changed
 
-- '@composes': remove all usages of `@composes` to avoid errors. ([@driesd](https://github.com/driesd) in [#15](https://github.com/teamleadercrm/ui-utilities/pull/15))
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+## [0.2.1] - 2020-01-06
+
+### Changed
+
+- `@composes`: remove all usages of `@composes` to avoid errors. ([@driesd](https://github.com/driesd) in [#15](https://github.com/teamleadercrm/ui-utilities/pull/15))
 
 ## [0.2.0] - 2019-11-19
 

--- a/index.css
+++ b/index.css
@@ -34,8 +34,11 @@
 }
 
 .reset {
-  composes: reset-box-sizing;
-  composes: reset-font-smoothing;
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-smoothing: antialiased;
+  text-size-adjust: 100%;
 }
 
 /* Box-shadows */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-utilities",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Teamleader UI utilities",
   "main": "index.css",
   "repository": {


### PR DESCRIPTION
This PR eliminates the usage of `@composes` in css files, to avoid the following error:
```
Error: composition is only allowed when selector is single :local class name not in ".reset", ".r
eset" is weird
```